### PR TITLE
column filter fixes

### DIFF
--- a/projects/simplemattable/readme.md
+++ b/projects/simplemattable/readme.md
@@ -35,7 +35,7 @@ Current test coverage (Statements/Branches/Functions/Lines): ~93%/~88%/~88%/~92%
 ## Prerequisites
 
 Simplemattable is for use with Angular Material Design only. As of the first version, 
-it requires Angular Material 6.0 or above. Also make sure to add @angular/flex-layout to your list of dependencies.
+it requires Angular Material 6.0. Later Versions require Angular Material 7.0 or above. Also make sure to add @angular/flex-layout to your list of dependencies.
 
 For a detailed list of neccessary dependencies, see [section Dependencies](#dependencies).
 
@@ -267,9 +267,6 @@ You do not need to use !important on ngStyle. For example, you could change the 
 
 - colFilter: (`.withColFilter()`): When activated, displays a column filter input below the header cell of the column. 
 The column filter works just like the filter feature of the table, but only filters rows using the values of the column.
-INFO: When using colFilter combined with sorting, pressing space while being in the column filter input will 
-trigger the sorting direction to change. If you have any idea of how to fix this, 
-feel free to give me a hint or to submit a pull request.
 
 ### Edit-mode
 

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -8,28 +8,27 @@
   <mat-table #table [dataSource]="dataSource" matSort [matSortDisabled]="!sorting">
     <ng-container *ngFor="let tcol of getDisplayedCols(this.columns); let columnIndex = index">
       <ng-container matColumnDef="{{columnIndex.toString() + '_' + tcol.property.toString()}}">
-        <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)">
+        <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)" [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm"
+                         [fxHide.sm]="tcol.hiddenSm">
           <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}"
                *ngIf="!tcol.colFilter">
             <span mat-sort-header [disabled]="!tcol.sortable"
-              [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
-              fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
-              [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+                  fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
+                  [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                 {{tcol.name}}
               </span>
           </div>
           <div fxLayout="column" *ngIf="tcol.colFilter">
             <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
               <span mat-sort-header [disabled]="!tcol.sortable"
-                [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
-                fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
-                [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+                    fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
+                    [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                   {{tcol.name}}
               </span>
             </div>
             <mat-form-field style="width: 100%;">
               <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
-                     (keyup)="applyColFilter($event)" (click)="$event.stopPropagation()">
+                     (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
             </mat-form-field>
           </div>
         </mat-header-cell>

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -8,21 +8,28 @@
   <mat-table #table [dataSource]="dataSource" matSort [matSortDisabled]="!sorting">
     <ng-container *ngFor="let tcol of getDisplayedCols(this.columns); let columnIndex = index">
       <ng-container matColumnDef="{{columnIndex.toString() + '_' + tcol.property.toString()}}">
-        <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)" mat-sort-header [disabled]="!tcol.sortable"
-                         [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
-                         fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
-                         [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+        <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)">
           <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}"
                *ngIf="!tcol.colFilter">
-            {{tcol.name}}
+            <span mat-sort-header [disabled]="!tcol.sortable"
+              [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
+              fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
+              [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+                {{tcol.name}}
+              </span>
           </div>
           <div fxLayout="column" *ngIf="tcol.colFilter">
             <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
-              {{tcol.name}}
+              <span mat-sort-header [disabled]="!tcol.sortable"
+                [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
+                fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
+                [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+                  {{tcol.name}}
+              </span>
             </div>
             <mat-form-field style="width: 100%;">
               <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
-                     (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
+                     (keyup)="applyColFilter($event)" (click)="$event.stopPropagation()">
             </mat-form-field>
           </div>
         </mat-header-cell>


### PR DESCRIPTION
Fixes #6 where users in Firefox and IE are not able to click on the column filter text input.
Fixes space bar issue mentioned in #4 so that when user presses the space bar while typing in the column filter text area, they will not affect the sort of that column.