### PR TITLE
Header alignment/layout improvements

### DIFF
--- a/projects/simplemattable/readme.md
+++ b/projects/simplemattable/readme.md
@@ -266,12 +266,23 @@ You do not need to use !important on ngStyle. For example, you could change the 
 `.withNgStyle((id) => ({'background-color': id < 3 ? '#992222' : 'transparent'}))`
 
 - colFilter: (`.withColFilter()`): When activated, displays a column filter input below the header cell of the column. 
-The column filter works just like the filter feature of the table, but only filters rows using the values of the column.
+The column filter works just like the filter feature of the table, but only filters rows using the values of the column. If you have problems with the width of the filter input, 
+have a look at the info in the Edit-mode chapter below.
 
 ### Edit-mode
 
 Edit-mode is a major feature of SimpleMatTable. It allows you to enable the add/edit/delete functionality.
 I will explain this feature using the ComplexTestData example from [the complex model section](#complex-model).
+
+INFO: If you have problems with form fields staying at 180px,
+try overriding the width property of the css class `.mat-form-field-infix` in your global style. This means putting the following code into your global style.css:
+```
+smc-simplemattable .mat-form-field-infix {
+  width: 100%!important;
+}
+``` 
+`.mat-form-field-infix` is a css class provided and used by Angular Material Design and not by simplemattable, 
+so it is your choice whether or not to touch it. 
 
 #### Enabling form fields for a column
 
@@ -482,6 +493,7 @@ You can find my email address in the [authors section](#authors).
 There will be new versions when new features are added or a new Angular version releases.
 
 History (Version in parenthesis is required Angular Version):
++ 1.6 (7.0): Multiline header cells
 + 1.5 (7.0): Filter for Columns
 + 1.4 (7.0): Updated to Angular 7
 + 1.3 (6.1): Sticky header option, Angular Version updated to 6.1 (6.4 @angular/material)

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -9,11 +9,11 @@
     <ng-container *ngFor="let tcol of getDisplayedCols(this.columns); let columnIndex = index">
       <ng-container matColumnDef="{{columnIndex.toString() + '_' + tcol.property.toString()}}">
         <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)" [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm"
+                         fxLayout="row" [fxLayoutAlign]="getHeaderAlign(tcol.align)"
                          [fxHide.sm]="tcol.hiddenSm">
           <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}"
                *ngIf="!tcol.colFilter">
             <span mat-sort-header [disabled]="!tcol.sortable"
-                  fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
                   [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                 {{tcol.name}}
               </span>
@@ -21,12 +21,11 @@
           <div fxLayout="column" *ngIf="tcol.colFilter">
             <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
               <span mat-sort-header [disabled]="!tcol.sortable"
-                    fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
                     [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                   {{tcol.name}}
               </span>
             </div>
-            <mat-form-field style="width: 100%;">
+            <mat-form-field style="width: 100%;" [ngStyle]="{'left': sorting ? isCenterAlign(tcol) ? '18px' : '5px' : '5px'}">
               <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
                      (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
             </mat-form-field>
@@ -36,7 +35,7 @@
         <mat-cell *matCellDef="let element; let rowIndex = index;" [fxFlex]="getFxFlex(tcol)"
                   [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm" [fxHide.sm]="tcol.hiddenSm"
                   (click)="onClick(tcol, element, false)"
-                  fxLayout="row" [fxLayoutAlign]="getAlign(tcol.align)"
+                  fxLayout="row" [fxLayoutAlign]="getCellAlign(tcol.align)"
                   [ngClass]="getCellCssClass(tcol, element)"
                   [ngStyle]="getCellCssStyle(tcol, element)">
 
@@ -106,7 +105,7 @@
 
           <!-- Standardcell: Icon + (Textarea or Span) -->
           <div *ngIf="!tcol.button && !isEditingColumn(tcol, element)" fxLayout="row" fxLayoutGap="5px"
-               [fxLayoutAlign]="getAlign(tcol.align)" [ngStyle.gt-xs]="{'padding':'0 5px'}" style="width: 100%;">
+               [fxLayoutAlign]="getCellAlign(tcol.align)" [ngStyle.gt-xs]="{'padding':'0 5px'}" style="width: 100%;">
             <mat-icon *ngIf="tcol.icon">{{getIconName(tcol, element)}}</mat-icon>
             <!-- Warning: Do not introduce linebreaks into the textareas content as they will be displayed -->
             <!-- Be careful when formatting -->

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -14,7 +14,7 @@
           <div fxLayout="column" *ngIf="!tcol.colFilter">
             <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
               <span mat-sort-header [disabled]="!tcol.sortable" fxLayout="row" [fxLayoutAlign]="getTextAlign(tcol.align)"
-                  [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
+                    [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                 {{tcol.name}}
               </span>
             </div>
@@ -26,11 +26,12 @@
                   {{tcol.name}}
               </span>
             </div>
-            <mat-form-field style="width: 100%;" [ngStyle]="{'left': sorting ? isCenterAlign(tcol) ? '18px' : isLeftAlign(tcol) ? '5px' : '0px' : isLeftAlign(tcol) ? '5px' : '0px'
-                                                            ,'text-align': getTextAlign(tcol.align)}">
-              <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
-                     (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
-            </mat-form-field>
+            <div style="padding: 0 5px">
+              <mat-form-field [ngStyle]="{'text-align': getTextAlign(tcol.align)}">
+                <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
+                       (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
+              </mat-form-field>
+            </div>
           </div>
         </mat-header-cell>
 

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -9,23 +9,25 @@
     <ng-container *ngFor="let tcol of getDisplayedCols(this.columns); let columnIndex = index">
       <ng-container matColumnDef="{{columnIndex.toString() + '_' + tcol.property.toString()}}">
         <mat-header-cell *matHeaderCellDef [fxFlex]="getFxFlex(tcol)" [fxHide.xs]="tcol.hiddenXs || tcol.hiddenSm"
-                         fxLayout="row" [fxLayoutAlign]="getHeaderAlign(tcol.align)"
+                         fxLayout="row" [fxLayoutAlign]="tcol.colFilter ? getHeaderFilterAlign(tcol.align) : getHeaderNoFilterAlign(tcol.align)"
                          [fxHide.sm]="tcol.hiddenSm">
-          <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}"
-               *ngIf="!tcol.colFilter">
-            <span mat-sort-header [disabled]="!tcol.sortable"
+          <div fxLayout="column" *ngIf="!tcol.colFilter">
+            <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
+              <span mat-sort-header [disabled]="!tcol.sortable" fxLayout="row" [fxLayoutAlign]="getTextAlign(tcol.align)"
                   [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                 {{tcol.name}}
               </span>
+            </div>
           </div>
           <div fxLayout="column" *ngIf="tcol.colFilter">
             <div [ngStyle.gt-xs]="{'padding': sorting ? isCenterAlign(tcol) ? '0 0 0 18px' : '0 0 0 5px' : '0 5px'}">
-              <span mat-sort-header [disabled]="!tcol.sortable"
+              <span mat-sort-header [disabled]="!tcol.sortable" fxLayout="row" [fxLayoutAlign]="getTextAlign(tcol.align)"
                     [ngClass]="{'no-sort': !(tcol.sortable && sorting), 'with-sort': tcol.sortable && sorting}">
                   {{tcol.name}}
               </span>
             </div>
-            <mat-form-field style="width: 100%;" [ngStyle]="{'left': sorting ? isCenterAlign(tcol) ? '18px' : '5px' : '5px'}">
+            <mat-form-field style="width: 100%;" [ngStyle]="{'left': sorting ? isCenterAlign(tcol) ? '18px' : isLeftAlign(tcol) ? '5px' : '0px' : isLeftAlign(tcol) ? '5px' : '0px'
+                                                            ,'text-align': getTextAlign(tcol.align)}">
               <input matInput placeholder="Filter" [formControl]="getColFilterFormControl(tcol)"
                      (keyup)="applyColFilter()" (click)="$event.stopPropagation()">
             </mat-form-field>

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
@@ -327,11 +327,12 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
   getIconName = (tcol: TableColumn<T, any>, element: T) => tcol.icon(element[tcol.property], element);
   getDisplayedCols = (cols: TableColumn<T, any>[]): TableColumn<T, any>[] => cols.filter(col => col.visible);
   getFxFlex = (tcol: TableColumn<T, any>): string => tcol.width ? tcol.width : '1 1 0px';
-  getAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center';
+  getHeaderAlign = (align: Align): string => align === Align.LEFT ? 'start end' : align === Align.CENTER ? 'center end' : 'end end'; 
+  getCellAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center';
   getTextAlign = (align: Align): string => align === Align.LEFT ? 'start' : align === Align.CENTER ? 'center' : 'end';
   isCenterAlign = (tcol: TableColumn<T, any>): boolean => tcol.align === Align.CENTER;
   hasColumnFilter = (): boolean => this.getDisplayedCols(this.columns).some(tcol => tcol.colFilter);
-  getTableHeaderStyle = (): Object => this.hasColumnFilter() ? {height: '66px'} : {};
+  getTableHeaderStyle = (): Object => this.hasColumnFilter() ? {height: '100%'} : {};
 
   arrayToObject(arr: string[]): Object { // turn ['css-class-a', 'css-class-b'] into {'css-class-a': true, 'css-class-b': true}
     return arr.reduce((acc, entry) => {

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
@@ -327,10 +327,12 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
   getIconName = (tcol: TableColumn<T, any>, element: T) => tcol.icon(element[tcol.property], element);
   getDisplayedCols = (cols: TableColumn<T, any>[]): TableColumn<T, any>[] => cols.filter(col => col.visible);
   getFxFlex = (tcol: TableColumn<T, any>): string => tcol.width ? tcol.width : '1 1 0px';
-  getHeaderAlign = (align: Align): string => align === Align.LEFT ? 'start end' : align === Align.CENTER ? 'center end' : 'end end'; 
+  getHeaderFilterAlign = (align: Align): string => align === Align.LEFT ? 'start end' : align === Align.CENTER ? 'center end' : 'end end'; 
+  getHeaderNoFilterAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center'; 
   getCellAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center';
   getTextAlign = (align: Align): string => align === Align.LEFT ? 'start' : align === Align.CENTER ? 'center' : 'end';
   isCenterAlign = (tcol: TableColumn<T, any>): boolean => tcol.align === Align.CENTER;
+  isLeftAlign = (tcol: TableColumn<T, any>): boolean => tcol.align === Align.LEFT;
   hasColumnFilter = (): boolean => this.getDisplayedCols(this.columns).some(tcol => tcol.colFilter);
   getTableHeaderStyle = (): Object => this.hasColumnFilter() ? {height: '100%'} : {};
 

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.components.spec.ts
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.components.spec.ts
@@ -380,9 +380,12 @@ describe('TestcompComponent', () => {
   });
   it('fxflex and align', () => {
     const tcol = hostComponent.tcolPlain;
-    expect(smt.getAlign(Align.LEFT)).toBe('start center');
-    expect(smt.getAlign(Align.CENTER)).toBe('center center');
-    expect(smt.getAlign(Align.RIGHT)).toBe('end center');
+    expect(smt.getHeaderAlign(Align.LEFT)).toBe('start end');
+    expect(smt.getHeaderAlign(Align.CENTER)).toBe('center end');
+    expect(smt.getHeaderAlign(Align.RIGHT)).toBe('end end');
+    expect(smt.getCellAlign(Align.LEFT)).toBe('start center');
+    expect(smt.getCellAlign(Align.CENTER)).toBe('center center');
+    expect(smt.getCellAlign(Align.RIGHT)).toBe('end center');
     expect(smt.getTextAlign(Align.LEFT)).toBe('start');
     expect(smt.getTextAlign(Align.CENTER)).toBe('center');
     expect(smt.getTextAlign(Align.RIGHT)).toBe('end');

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.components.spec.ts
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.components.spec.ts
@@ -380,9 +380,12 @@ describe('TestcompComponent', () => {
   });
   it('fxflex and align', () => {
     const tcol = hostComponent.tcolPlain;
-    expect(smt.getHeaderAlign(Align.LEFT)).toBe('start end');
-    expect(smt.getHeaderAlign(Align.CENTER)).toBe('center end');
-    expect(smt.getHeaderAlign(Align.RIGHT)).toBe('end end');
+    expect(smt.getHeaderFilterAlign(Align.LEFT)).toBe('start end');
+    expect(smt.getHeaderFilterAlign(Align.CENTER)).toBe('center end');
+    expect(smt.getHeaderFilterAlign(Align.RIGHT)).toBe('end end');
+    expect(smt.getHeaderNoFilterAlign(Align.LEFT)).toBe('start center');
+    expect(smt.getHeaderNoFilterAlign(Align.CENTER)).toBe('center center');
+    expect(smt.getHeaderNoFilterAlign(Align.RIGHT)).toBe('end center');
     expect(smt.getCellAlign(Align.LEFT)).toBe('start center');
     expect(smt.getCellAlign(Align.CENTER)).toBe('center center');
     expect(smt.getCellAlign(Align.RIGHT)).toBe('end center');
@@ -406,6 +409,12 @@ describe('TestcompComponent', () => {
     expect(smt.isCenterAlign(tcol)).toBe(false);
     tcol.withAlign(Align.RIGHT);
     expect(smt.isCenterAlign(tcol)).toBe(false);
+    tcol.withAlign(Align.CENTER);
+    expect(smt.isLeftAlign(tcol)).toBe(false);
+    tcol.withAlign(Align.LEFT);
+    expect(smt.isLeftAlign(tcol)).toBe(true);
+    tcol.withAlign(Align.RIGHT);
+    expect(smt.isLeftAlign(tcol)).toBe(false);
   });
   it('array to object, iterator to array, deep copy', () => {
     // array to object

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,20 +36,20 @@ export class AppComponent implements OnInit {
     d3.setMonth(3);
     d3.setFullYear(2017);
     this.testData = [
-      new ComplexTestData(1, 40, 'test1', new TestData('Key1', 'Value1', d1)),
-      new ComplexTestData(2, 41, '', new TestData('Key2', 'Value2', d2)),
-      new ComplexTestData(3, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(4, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(5, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(6, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(7, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(1, 40, 'test1', new TestData('Key1', 'Value1', d1)),
-      new ComplexTestData(2, 41, '', new TestData('Key2', 'Value2', d2)),
-      new ComplexTestData(3, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(4, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(5, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(6, 39, 'test3', new TestData('Key3', 'Value3', d3)),
-      new ComplexTestData(7, 39, 'test3', new TestData('Key3', 'Value3', d3))
+      new ComplexTestData(1, 40, 'test1', new TestData('Key1', 'Value1', d1), 'test1'),
+      new ComplexTestData(2, 41, '', new TestData('Key2', 'Value2', d2), ''),
+      new ComplexTestData(3, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(4, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(5, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(6, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(7, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(1, 40, 'test1', new TestData('Key1', 'Value1', d1), 'test1'),
+      new ComplexTestData(2, 41, '', new TestData('Key2', 'Value2', d2), ''),
+      new ComplexTestData(3, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(4, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(5, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(6, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3'),
+      new ComplexTestData(7, 39, 'test3', new TestData('Key3', 'Value3', d3), 'test3')
     ];
 
     const idCol = new TableColumn<ComplexTestData, 'id'>('ID with button', 'id')
@@ -62,7 +62,8 @@ export class AppComponent implements OnInit {
       .withColFilter()
       .isHiddenSm(true);
     const valueCol = new TableColumn<ComplexTestData, 'value'>('Number with select', 'value')
-      .withColFilter();
+      .withColFilter()
+      .withAlign(Align.CENTER);
     valueCol.withFormField(valueCol.getSelectFormField<number>()
       .withOptions([
         {display: '39', value: 39},
@@ -76,7 +77,8 @@ export class AppComponent implements OnInit {
         {key: 'min', msg: 'Value should be at least 25!'}
       ]));
     const testErrorCol = new TableColumn<ComplexTestData, 'data'>('Profile', 'data')
-      .withTransform(data => data.value);
+      .withTransform(data => data.value)
+      .withAlign(Align.CENTER);
     testErrorCol.withFormField(testErrorCol.getSelectFormField<string>()
       .withOptions([
         {display: 'Valideur', value: 'Valideur'},
@@ -101,7 +103,8 @@ export class AppComponent implements OnInit {
       .withApply((id, data) => {
         data.key = id;
         return data;
-      }));
+      }))
+      .withAlign(Align.RIGHT);
     const valCol = new TableColumn<ComplexTestData, 'data'>('Value with icon', 'data')
       .isHiddenXs(true)
       .withNgClass(() => 'red-bg-cell')
@@ -111,7 +114,8 @@ export class AppComponent implements OnInit {
     const dateCol = new TableColumn<ComplexTestData, 'data'>('Date right align', 'data')
       .withTransform((data) => this.getDateStr(data.date))
       .withSortTransform(data => data.date.toISOString())
-      .withAlign(Align.RIGHT);
+      .withAlign(Align.RIGHT)
+      .withColFilter();
     dateCol.withFormField(dateCol.getDateFormField()
       .withHint('Only past dates.')
       .withPlaceholder('Date')
@@ -126,8 +130,10 @@ export class AppComponent implements OnInit {
         return data;
       })
     );
-    this.columns = [idCol, testErrorCol, desCol, des2Col, valueCol, keyCol, valCol, dateCol];
-    this.columns2 = [idCol, desCol, des2Col, valueCol, keyCol, valCol, dateCol];
+    const multilineCol = new TableColumn<ComplexTestData, 'notes'>('This header will take multiple lines to display the header', 'notes')
+      .withColFilter();
+    this.columns = [idCol, testErrorCol, desCol, des2Col, valueCol, keyCol, valCol, dateCol, multilineCol];
+    this.columns2 = [idCol, desCol, des2Col, valueCol, keyCol, valCol, dateCol, multilineCol];
   }
 
   pastDateValidator = (control: AbstractControl) => control.value < new Date() ? null : {'pastDate': true};
@@ -143,7 +149,7 @@ export class AppComponent implements OnInit {
 
   addEntry() {
     this.testData.push(new ComplexTestData(42, 420, 'New Entry with a lot of text that is very long like really really long ' +
-      'i mean really really long i really mean it', new TestData('key', 'value', new Date())));
+      'i mean really really long i really mean it', new TestData('key', 'value', new Date()), 'New Entry with a lot of text that is very long like really really long i mean really really long i really mean it'));
     this.testData = this.testData.slice(0);
   }
 
@@ -196,7 +202,7 @@ export class AppComponent implements OnInit {
   }
 
   createFn(): ComplexTestData {
-    return new ComplexTestData(0, 42, '', new TestData('', '', new Date()));
+    return new ComplexTestData(0, 42, '', new TestData('', '', new Date()), '');
   }
 
 }
@@ -207,6 +213,6 @@ class TestData {
 }
 
 class ComplexTestData {
-  constructor(public id: number, public value: number, public description: string, public data: TestData) {
+  constructor(public id: number, public value: number, public description: string, public data: TestData, public notes: string) {
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,3 +5,7 @@
   background: #992222!important;
   color: white;
 }
+
+smc-simplemattable .mat-form-field-infix {
+  width: 100%!important;
+}


### PR DESCRIPTION
I encountered some issues when using simplemattable. Specifically, if you have a lot of columns and/or when some column(s) have multi-line headers. Unfortunately, in my case I am not free to shorten the column headings so I needed to find a different solution.

Specifically:
- Multi-line header text was cutoff/missing.
- The header text was not vertically aligned in a pleasing way. I know this is subjective, but I found that having the Filter input fields at various heights was distracting.
- If using Align.RIGHT, the header text would sometimes be placed outside of the visible area so that the "Filter" placeholder could be shown.

Here's an example screen snippet showing the original issue:
![image](https://user-images.githubusercontent.com/18578940/52080429-bf204b00-2565-11e9-8304-20e40e8d9c64.png)

In general, the things I changed were:
- Remove hard coded 66px height setting so that header text is not cutoff.
- If column filters are present, use flex alignment end so that the Filter lines are in the same position.
- If column filters are not present, use flex alignment center so that non-filter headings don't get stuck next to Filter text inputs.
- Make sure column heading and, if applicable, Filter text input, have matching alignment. This should help to reduce conflicts where the heading is at the far right but is cut off because the Filter placeholder is at the far left and there isn't enough width to show both.
- Add 'left' CSS attribute to mat-form-field element with matching padding so that the beginning of the "Filter" text is not cutoff due to the 18px (or 5px) padding applied to the sibling div.

In addition to the changs above, I also added tests for the methods I added and I also added a new column to the demo HTML so you can see a test case where the issue was happening.

Here's an example screen snippet showing after the changes:
![image](https://user-images.githubusercontent.com/18578940/52079873-88960080-2564-11e9-8954-90fa55a3dd52.png)

Thanks for reviewing it.