### PR TITLE
Add Multiple Prameter To TableColumn Optionally 

### DIFF
--- a/projects/simplemattable/src/lib/external-component-wrapper/external-component-wrapper.component.ts
+++ b/projects/simplemattable/src/lib/external-component-wrapper/external-component-wrapper.component.ts
@@ -8,8 +8,14 @@ import {Component, ComponentFactoryResolver, ComponentRef, Input, OnChanges, Typ
 export class ExternalComponentWrapperComponent implements OnChanges {
 
   @Input() ngComponent: Type<any>;
-  @Input() ngComponentInput: (component: any, data: any, dataParent: any) => void;
+  @Input() ngComponentInput: (component: any, data: any,
+    secondData?: any, thirdData?: any,
+    fourthData?: any, fifthData?: any, dataParent?: any) => void;
   @Input() tcolProperty: any;
+  @Input() secondProperty: any;
+  @Input() thirdProperty: any;
+  @Input() fourthProperty: any;
+  @Input() fifthProperty: any;
   @Input() dataParent: any;
 
   private componentRef: ComponentRef<any>;
@@ -21,12 +27,20 @@ export class ExternalComponentWrapperComponent implements OnChanges {
     this.viewContainerRef.clear();
     this.componentRef = this.viewContainerRef.createComponent(this.resolver.resolveComponentFactory(this.ngComponent));
     if (this.ngComponentInput) {
-      this.ngComponentInput(this.componentRef.instance, this.dataParent[this.tcolProperty], this.dataParent);
+      this.ngComponentInput(this.componentRef.instance,
+        this.dataParent[this.tcolProperty],
+        this.dataParent[this.secondProperty], this.dataParent[this.thirdProperty],
+        this.dataParent[this.fourthProperty], this.dataParent[this.fifthProperty],
+        this.dataParent);
     }
   }
 
   refreshInput() {
-    this.ngComponentInput(this.componentRef.instance, this.dataParent[this.tcolProperty], this.dataParent);
+    this.ngComponentInput(this.componentRef.instance,
+      this.dataParent[this.tcolProperty],
+      this.dataParent[this.secondProperty], this.dataParent[this.thirdProperty],
+      this.dataParent[this.fourthProperty], this.dataParent[this.fifthProperty],
+      this.dataParent);
   }
 
 }

--- a/projects/simplemattable/src/lib/model/table-column.model.ts
+++ b/projects/simplemattable/src/lib/model/table-column.model.ts
@@ -19,7 +19,7 @@ export class TableColumn<T,
   X extends (keyof T | never) = never,
   W extends (keyof T | never) = never> {
 
-  public transform: (data: T[P], dataParent: T) => string;
+  public transform: (data: T[P], dataParent?: T) => string;
   public width: string;
   public heightFn: (data: T[P], dataParent: T) => Height;
   public disabledFn: (data: T[P], dataParent: T) => boolean;

--- a/projects/simplemattable/src/lib/model/table-column.model.ts
+++ b/projects/simplemattable/src/lib/model/table-column.model.ts
@@ -12,7 +12,12 @@ import {Height} from './height.model';
 import {CheckboxFormField} from './checkbox-form-field.model';
 import {Type} from '@angular/core';
 
-export class TableColumn<T, P extends keyof T> {
+export class TableColumn<T,
+  P extends keyof T,
+  Z extends (keyof T | never) = never,
+  Y extends (keyof T | never) = never,
+  X extends (keyof T | never) = never,
+  W extends (keyof T | never) = never> {
 
   public transform: (data: T[P], dataParent: T) => string;
   public width: string;
@@ -41,7 +46,9 @@ export class TableColumn<T, P extends keyof T> {
   public sticky: boolean = false;
   public stickyEnd: boolean = false;
   public ngComponent: Type<any>;
-  public ngComponentInput: (component: any, data: T[P], dataParent: T) => void;
+  public ngComponentInput: (component: any, data: T[P],
+    secondData?: T[Z], thirdData?: T[Y],
+    fourthData?: T[X], fifthData?: T[W], dataParent?: T) => void;
 
   private colFilterText: ColFilterTextHolder = {
     applied: true,
@@ -49,7 +56,9 @@ export class TableColumn<T, P extends keyof T> {
   };
 
   constructor(public name: string,
-              public property: P) {
+    public property: P,
+    public secondProperty?: Z, public thirdProperty?: Y,
+    public fourthProperty?: X, public fifthProperty?: W) {
   }
 
   /**
@@ -63,6 +72,7 @@ export class TableColumn<T, P extends keyof T> {
     this.transform = transformFn;
     return this;
   }
+
 
   /**
    * Function that returns the sort value of a cell.
@@ -350,7 +360,11 @@ export class TableColumn<T, P extends keyof T> {
    *
    * @param ngComponentInput
    */
-  public withNgComponentInput(ngComponentInput: (component: any, data: T[P], dataParent: T) => void) {
+  public withNgComponentInput(ngComponentInput: (component: any,
+    data: T[P],
+    secondData?: T[Z], thirdData?: T[Y],
+    fourthData?: T[X], fifthData?: T[W],
+    dataParent?: T) => void) {
     this.ngComponentInput = ngComponentInput;
     return this;
   }
@@ -461,7 +475,6 @@ export class TableColumn<T, P extends keyof T> {
 
 
 }
-
 interface ColFilterTextHolder {
   text: string;
   applied: boolean;

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.html
@@ -11,7 +11,7 @@
 <div fxFlex [ngStyle]="getOuterContainerStyle()" (scroll)="onScrollComponent($event)" #scrollContainer
      id="smtScrollContainer">
   <table mat-table [dataSource]="dataSource" matSort [matSortDisabled]="!sorting" style="width: 100%"
-         [ngClass]="getTableClass()">
+         (matSortChange)="sortChanged($event)" [ngClass]="getTableClass()">
     <ng-container *ngFor="let tcol of getDisplayedCols(columns); let columnIndex = index">
       <ng-container matColumnDef="{{columnIndex.toString() + '_' + tcol.property.toString()}}"
                     [sticky]="tcol.sticky" [stickyEnd]="tcol.stickyEnd">
@@ -191,6 +191,9 @@
                   <smc-external-component-wrapper
                     *ngIf="tcol.ngComponent; else tdDefault"
                     [dataParent]="element" [tcolProperty]="tcol.property"
+                     [secondProperty]="tcol.secondProperty" [thirdProperty]="tcol.thirdProperty"
+                      [fourthProperty]="tcol.fourthProperty" [fifthProperty]="tcol.fifthProperty"
+
                     [ngComponent]="tcol.ngComponent" [ngComponentInput]="tcol.ngComponentInput"
                   ></smc-external-component-wrapper>
                 </ng-template>

--- a/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
+++ b/projects/simplemattable/src/lib/simplemattable/simplemattable.component.ts
@@ -37,7 +37,7 @@ import {ExternalComponentWrapperComponent} from '../external-component-wrapper/e
 export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, AfterViewInit {
 
   @Input() data: T[] = [];
-  @Input() columns: TableColumn<T, any, any>[] = [];
+  @Input() columns: TableColumn<T, any, any, any, any, any>[] = [];
   @Input() filter: boolean = false;
   @Input() filterLabel: string = 'Filter';
   @Input() noOpFilter: boolean = false;
@@ -93,12 +93,12 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
   displayedColumns = [];
   dataSource: MatTableDataSource<T>;
   private dataStatus: Map<T, DataStatus> = new Map<T, DataStatus>(); // to know whether or not a row is being edited
-  private oldColumns: TableColumn<T, any,any>[] = []; // For dirty-checking
+  private oldColumns: TableColumn<T, any, any, any, any, any>[] = []; // For dirty-checking
   addedItem: T = null;
   // There may only be one form control per cell
   // FormControls are identified by <rowIndex>_<colIndex>
   formControls: Map<string, AbstractControl> = new Map<string, AbstractControl>();
-  colFilterFormControls = new Map<TableColumn<T, any, any>, AbstractControl>();
+  colFilterFormControls = new Map<TableColumn<T, any, any, any, any, any>, AbstractControl>();
 
   buttonType = ButtonType;
   formFieldType = FormFieldType;
@@ -179,7 +179,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
    * @param element Clicked element
    * @param fromButton true = button; false = cell
    */
-  onClick(tcol: TableColumn<T, any, any>, element: T, fromButton: boolean) {
+  onClick(tcol: TableColumn<T, any, any, any, any, any>, element: T, fromButton: boolean) {
     if (fromButton ? this.isButtonClickable(tcol) : this.isCellClickable(tcol, element)) {
       tcol.onClick(element[tcol.property], element);
     }
@@ -270,7 +270,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
    * @param element the element
    * @returns ngClass Object
    */
-  getCellCssClass(tcol: TableColumn<T, any, any>, element: T): Object {
+  getCellCssClass(tcol: TableColumn<T, any, any, any, any, any>, element: T): Object {
     const defaultClass = {'filler-div': true, 'on-click': (tcol.onClick && !tcol.button)};
     if (!tcol.ngClass) {
       return defaultClass;
@@ -296,7 +296,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
    * @param element
    * @returns ngStyleObject
    */
-  getCellCssStyle(tcol: TableColumn<T, any, any>, element: T): Object {
+  getCellCssStyle(tcol: TableColumn<T, any, any, any, any, any>, element: T): Object {
     const baseValue = tcol.ngStyle ? tcol.ngStyle(element[tcol.property], element) : {};
     baseValue['textAlign'] = this.getTextAlign(tcol.align);
     if (tcol.heightFn) {
@@ -310,7 +310,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
     return baseValue;
   }
 
-  getTableCellStyle(tcol: TableColumn<T, any, any>): { [p: string]: string } {
+  getTableCellStyle(tcol: TableColumn<T, any, any, any, any, any>): { [p: string]: string } {
     if (tcol.width) {
       return {'width': tcol.width.toString()};
     } else {
@@ -355,7 +355,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
    * @param element Element, used to set the initial value if creation of a new control is necessary
    * @returns AbstractFormControl
    */
-  getFormControl(rowIndex: number, colIndex: number, tcol: TableColumn<T, any, any>, element: T): AbstractControl {
+  getFormControl(rowIndex: number, colIndex: number, tcol: TableColumn<T, any, any, any, any, any>, element: T): AbstractControl {
     const id = rowIndex + '_' + colIndex;
     if (this.formControls.has(id)) {
       return this.formControls.get(id);
@@ -367,7 +367,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
     }
   }
 
-  getColFilterFormControl(tableColumn: TableColumn<T, any, any>): AbstractControl {
+  getColFilterFormControl(tableColumn: TableColumn<T, any, any, any, any, any>): AbstractControl {
     return this.colFilterFormControls.get(tableColumn);
   }
 
@@ -393,7 +393,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
    * @param element
    * @returns List of FormError objects that are currently active (their condition is met)
    */
-  getCurrentErrors(rowIndex: number, colIndex: number, tcol: TableColumn<T, any, any>, element: T): FormError[] {
+  getCurrentErrors(rowIndex: number, colIndex: number, tcol: TableColumn<T, any, any, any, any, any>, element: T): FormError[] {
     const formField = this.getFormControl(rowIndex, colIndex, tcol, element);
     return tcol.formField.errors.filter(error => formField.hasError(error.key));
   }
@@ -434,7 +434,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
     }
     const element = this.deepCopy(oldElement); // Deep copy old object to not override table values
     controls.forEach(control => {
-      const tcol: TableColumn<T, any, any> = this.getDisplayedCols(this.columns)[control.col];
+      const tcol: TableColumn<T, any, any, any, any, any> = this.getDisplayedCols(this.columns)[control.col];
       const val = control.control.value;
       if (element[tcol.property] instanceof Object && !(element[tcol.property] instanceof Date) && !tcol.formField.apply) {
         throw Error('Could not map value "' + val + '" to property "' + tcol.property + '". ' +
@@ -511,7 +511,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
     }
   }
 
-  directEditElementChanged(tcol: TableColumn<T, any, any>, element: T, newValue) {
+  directEditElementChanged(tcol: TableColumn<T, any, any, any, any, any>, element: T, newValue) {
     if (tcol.formField.onDirectEditModelChange) {
       tcol.formField.onDirectEditModelChange(newValue, element[tcol.property], element);
     } else {
@@ -527,7 +527,7 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
 
    */
 
-  getStringRepresentation(tcol: TableColumn<T, any, any>, element: T): string {
+  getStringRepresentation(tcol: TableColumn<T, any, any, any, any, any>, element: T): string {
     if (tcol.transform) {
       return tcol.transform(element[tcol.property], element);
     } else if (element[tcol.property] === null || element[tcol.property] === undefined) {
@@ -537,27 +537,27 @@ export class SimplemattableComponent<T> implements OnInit, DoCheck, OnChanges, A
     }
   }
 
-  private isButtonClickable = (tcol: TableColumn<T, any, any>) => tcol.onClick && tcol.button;
-  private isCellClickable = (tcol: TableColumn<T, any, any>, element: T) => tcol.onClick && !tcol.button && !this.isEditing(element);
+  private isButtonClickable = (tcol: TableColumn<T, any, any, any, any, any>) => tcol.onClick && tcol.button;
+  private isCellClickable = (tcol: TableColumn<T, any, any, any, any, any>, element: T) => tcol.onClick && !tcol.button && !this.isEditing(element);
 
   getFormFieldMaxLines = (formField) => formField.maxLines;
   getFormFieldMinLines = (formField) => formField.minLines;
   getFormFieldOptions = (formField) => formField.options;
   isLoading = (element: T): boolean => this.dataStatus.get(element).loading;
   isEditing = (element: T): boolean => this.dataStatus.get(element).editing;
-  isEditingColumn = (tcol: TableColumn<T, any, any>, element: T): boolean => tcol.formField && !tcol.directEdit && this.isEditing(element);
-  getIconName = (tcol: TableColumn<T, any, any>, element: T) => tcol.icon(element[tcol.property], element);
-  getDisplayedCols = (cols: TableColumn<T, any, any>[]): TableColumn<T, any, any>[] => cols.filter(col => col.visible);
+  isEditingColumn = (tcol: TableColumn<T, any, any, any, any, any>, element: T): boolean => tcol.formField && !tcol.directEdit && this.isEditing(element);
+  getIconName = (tcol: TableColumn<T, any, any, any, any, any>, element: T) => tcol.icon(element[tcol.property], element);
+  getDisplayedCols = (cols: TableColumn<T, any, any, any, any, any>[]): TableColumn<T, any, any, any, any, any>[] => cols.filter(col => col.visible);
   getHeaderFilterAlign = (align: Align): string => align === Align.LEFT ? 'start end' : align === Align.CENTER ? 'center end' : 'end end';
   getHeaderNoFilterAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center';
   getCellAlign = (align: Align): string => align === Align.LEFT ? 'start center' : align === Align.CENTER ? 'center center' : 'end center';
   getTextAlign = (align: Align): string => align === Align.LEFT ? 'start' : align === Align.CENTER ? 'center' : 'end';
-  isCenterAlign = (tcol: TableColumn<T, any, any>): boolean => tcol.align === Align.CENTER;
-  isLeftAlign = (tcol: TableColumn<T, any, any>): boolean => tcol.align === Align.LEFT;
+  isCenterAlign = (tcol: TableColumn<T, any, any, any, any, any>): boolean => tcol.align === Align.CENTER;
+  isLeftAlign = (tcol: TableColumn<T, any, any, any, any, any>): boolean => tcol.align === Align.LEFT;
   hasColumnFilter = (): boolean => this.getDisplayedCols(this.columns).some(tcol => tcol.colFilter);
   getTableHeaderStyle = (): Object => this.hasColumnFilter() ? {height: '100%'} : {};
   getTableClass = (): string => (this.sticky ? 'sticky-th' : 'non-sticky-th') + (this.isChrome ? ' chrome' : '');
-  isButtonDisabled = (tcol: TableColumn<T, any, any>, element: T): boolean => tcol.disabledFn ? tcol.disabledFn(element[tcol.property], element) : false;
+  isButtonDisabled = (tcol: TableColumn<T, any, any, any, any, any>, element: T): boolean => tcol.disabledFn ? tcol.disabledFn(element[tcol.property], element) : false;
 
   getOuterContainerStyle() {
     return {


### PR DESCRIPTION
I add this functionality because some times we need the id of the entity in other columns or other properties
so the library had one parameter and I add 4 optional one to be used like this

`
 new TableColumn<Entry, 'id'>('ID', 'id')
      }),
new TableColumn<Entry, 'a', 'b', 'c', 'id'>('ABC', 'a', 'b', 'c', 'id')
      .withNgComponent(CheckboxMPComponent)
      .withNgComponentInput((component: CheckboxMPComponent, a, b, c, id) => {
      }),
`